### PR TITLE
Configure ICMP protocol.

### DIFF
--- a/ansible/configs/rhel-security/env_vars.yml
+++ b/ansible/configs/rhel-security/env_vars.yml
@@ -26,6 +26,13 @@ node_instance_count: 9
 security_groups:
   - name: OpenEverythingSG
     rules:
+    - name: AllowICMP
+      description: "Local network"
+      from_port: -1
+      to_port: -1
+      protocol: icmp
+      cidr: 0.0.0.0/0
+      rule_type: Ingress
     - name: SSH
       description: "SSH public"
       from_port: 22


### PR DESCRIPTION
Enable ICMP protocol so we can ping between nodes and bastion.
```
[root@bastion 2 ~]# ping -c 2 node1.ggasparb.internal
PING node1.ggasparb.internal (192.168.0.179) 56(84) bytes of data.
64 bytes from ip-192-168-0-179.eu-central-1.compute.internal (192.168.0.179): icmp_seq=1 ttl=64 time=0.433 ms
64 bytes from ip-192-168-0-179.eu-central-1.compute.internal (192.168.0.179): icmp_seq=2 ttl=64 time=0.447 ms

--- node1.ggasparb.internal ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 35ms
rtt min/avg/max/mdev = 0.433/0.440/0.447/0.007 ms
```

```
[ec2-user@node1 ~]$ ping -c 2 node2
PING node2.ggasparb.internal (192.168.0.190) 56(84) bytes of data.
64 bytes from ip-192-168-0-190.eu-central-1.compute.internal (192.168.0.190): icmp_seq=1 ttl=64 time=0.404 ms
64 bytes from ip-192-168-0-190.eu-central-1.compute.internal (192.168.0.190): icmp_seq=2 ttl=64 time=1.01 ms

--- node2.ggasparb.internal ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 53ms
rtt min/avg/max/mdev = 0.404/0.709/1.014/0.305 ms
```
@lkerner this PR also helps IPSec lab from here since it uses `ping`: https://github.com/RedHatDemos/SecurityDemos/blob/master/2020Labs/RHELSecurity/documentation/lab4_IPsec.adoc