### PR TITLE
Fix selinux-policy verification role.

### DIFF
--- a/ansible/roles/selinux-policy/tasks/main.yml
+++ b/ansible/roles/selinux-policy/tasks/main.yml
@@ -1,13 +1,6 @@
 ---
-hosts: all
-become: yes
-
-- name: Configure bastion for SELinux workshop
-  hosts: all
-  gather_facts: false
-  become: true
-  tasks:
-  - name: Install all needed packages
+- name: Install all needed packages
+  block:
     package:
       state: present
       name:
@@ -39,21 +32,21 @@ become: yes
         - cockpit-storaged
     check_mode: yes
 
-  - name: Ensure cockpit is started
-    systemd:
-      name: "cockpit.socket"
-      state: "started"
-      enabled: true
-      daemon_reload: true
-    check_mode: yes
+- name: Ensure cockpit is started
+  systemd:
+    name: "cockpit.socket"
+    state: "started"
+    enabled: true
+    daemon_reload: true
+  check_mode: yes
 
-  - name: Check if SELinux is in Enforcing state
-    selinux:
-      policy: targeted
-      state: enforcing
-    check_mode: yes
+- name: Check if SELinux is in Enforcing state
+  selinux:
+    policy: targeted
+    state: enforcing
+  check_mode: yes
 
-  - name: Check if testaudit file exists
-    stat:
-        path: /root/testaudit
+- name: Check if testaudit file exists
+  stat:
+      path: /root/testaudit
 


### PR DESCRIPTION
When I execute this role I was getting syntax error:
```
ERROR! Syntax Error while loading YAML.
  did not find expected key

The error appears to be in '/home/ggasparb/workspace/github/agnosticd/ansible/roles/selinux-policy/tasks/main.yml': line 5, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Configure bastion for SELinux workshop
^ here
```