### PR TITLE
Improvements on RHEL Security lab

### DIFF
--- a/ansible/configs/rhel-security/env_vars.yml
+++ b/ansible/configs/rhel-security/env_vars.yml
@@ -448,15 +448,16 @@ instances:
       - DefaultSG
       - OpenEverythingSG
 
-  - name: "rhel7selinux"
+  - name: "selinuxrhel7"
     count: 1
+    unique: true
     public_dns: false
     dns_loadbalancer: false
     image: "{{ node7_instance_image }}"
     flavor: "{{ node_instance_type }}"
     tags:
       - key: "AnsibleGroup"
-        value: "rhel7selinux"
+        value: "selinuxrhel7"
       - key: "ostype"
         value: "linux"
       - key: "instance_filter"

--- a/ansible/configs/rhel-security/env_vars.yml
+++ b/ansible/configs/rhel-security/env_vars.yml
@@ -10,7 +10,7 @@ bastion_instance_type:
   azure: Standard_A2_V2
   osp: 2c2g30d
 
-bastion_instance_image: RHEL75
+bastion_instance_image: RHEL81
 
 node_instance_type:
   ec2: "t2.medium"
@@ -22,8 +22,6 @@ node7_instance_image: RHEL75
 
 
 # How many do you want for each instance type
-node_instance_count: 9
-node7_instance_count: 1
 
 security_groups:
   - name: RemoteDesktopRDPSG
@@ -269,7 +267,7 @@ instances:
     flavor: "{{ bastion_instance_type }}"
     tags:
       - key: "AnsibleGroup"
-        value: "openscaps"
+        value: "openscap"
       - key: "ostype"
         value: "linux"
       - key: "instance_filter"
@@ -283,7 +281,7 @@ instances:
       - RemoteDesktopRDPSG
       - RemoteDesktopVNCSG
 
-  - name: "idm"
+  - name: "idmserver"
     count: 1
     unique: true
     public_dns: true
@@ -306,37 +304,16 @@ instances:
       - OpenEverythingSG
       - RemoteDesktopRDPSG
       - RemoteDesktopVNCSG
-  
-  - name: "ipsec"
-    count: 2
-    public_dns: false
-    dns_loadbalancer: false
-    image: "{{ bastion_instance_image }}"
-    flavor: "{{ bastion_instance_type }}"
-    tags:
-      - key: "AnsibleGroup"
-        value: "ipseclab"
-      - key: "ostype"
-        value: "linux"
-      - key: "instance_filter"
-        value: "{{ env_type }}-{{ email }}"
-    volumes:
-      - name: '/dev/sda1'
-        size: 20
-    security_groups:
-      - BastionSG
-      - OpenIPSECports
-      - OpenEverythingSG
 
-  - name: "node"
-    count: "{{ node_instance_count }}"
+  - name: "idm"
+    count: 2
     public_dns: false
     dns_loadbalancer: false
     image: "{{ node_instance_image }}"
     flavor: "{{ node_instance_type }}"
     tags:
       - key: "AnsibleGroup"
-        value: "nodes"
+        value: "idm"
       - key: "ostype"
         value: "linux"
       - key: "instance_filter"
@@ -345,15 +322,141 @@ instances:
       - DefaultSG
       - OpenEverythingSG
 
-  - name: "node7"
-    count: "{{node7_instance_count}}"
+  - name: "aide"
+    count: 1
+    unique: true
+    public_dns: false
+    dns_loadbalancer: false
+    image: "{{ node_instance_image }}"
+    flavor: "{{ node_instance_type }}"
+    tags:
+      - key: "AnsibleGroup"
+        value: "aide"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    security_groups:
+      - DefaultSG
+      - OpenEverythingSG
+
+  - name: "gpg"
+    count: 1
+    unique: true
+    public_dns: false
+    dns_loadbalancer: false
+    image: "{{ node_instance_image }}"
+    flavor: "{{ node_instance_type }}"
+    tags:
+      - key: "AnsibleGroup"
+        value: "gpg"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    security_groups:
+      - DefaultSG
+      - OpenEverythingSG
+
+  - name: "audit"
+    count: 1
+    unique: true
+    public_dns: false
+    dns_loadbalancer: false
+    image: "{{ node_instance_image }}"
+    flavor: "{{ node_instance_type }}"
+    tags:
+      - key: "AnsibleGroup"
+        value: "audit"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    security_groups:
+      - DefaultSG
+      - OpenEverythingSG
+
+  - name: "firewalld"
+    count: 1
+    unique: true
+    public_dns: false
+    dns_loadbalancer: false
+    image: "{{ node_instance_image }}"
+    flavor: "{{ node_instance_type }}"
+    tags:
+      - key: "AnsibleGroup"
+        value: "firewalld"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    security_groups:
+      - DefaultSG
+      - OpenEverythingSG
+
+  - name: "ipsec"
+    count: 2
+    public_dns: false
+    dns_loadbalancer: false
+    image: "{{ node_instance_image }}"
+    flavor: "{{ node_instance_type }}"
+    tags:
+      - key: "AnsibleGroup"
+        value: "ipsec"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    security_groups:
+      - DefaultSG
+      - OpenIPSECports
+      - OpenEverythingSG
+
+  - name: "cryptopolicies"
+    count: 1
+    unique: true
+    public_dns: false
+    dns_loadbalancer: false
+    image: "{{ node_instance_image }}"
+    flavor: "{{ node_instance_type }}"
+    tags:
+      - key: "AnsibleGroup"
+        value: "cryptopolicies"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    security_groups:
+      - DefaultSG
+      - OpenEverythingSG
+
+  - name: "sessionrecording"
+    count: 1
+    unique: true
+    public_dns: false
+    dns_loadbalancer: false
+    image: "{{ node_instance_image }}"
+    flavor: "{{ node_instance_type }}"
+    tags:
+      - key: "AnsibleGroup"
+        value: "sessionrecording"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    security_groups:
+      - DefaultSG
+      - OpenEverythingSG
+
+  - name: "rhel7selinux"
+    count: 1
     public_dns: false
     dns_loadbalancer: false
     image: "{{ node7_instance_image }}"
     flavor: "{{ node_instance_type }}"
     tags:
       - key: "AnsibleGroup"
-        value: "nodes"
+        value: "rhel7selinux"
       - key: "ostype"
         value: "linux"
       - key: "instance_filter"

--- a/ansible/configs/rhel-security/idm.yml
+++ b/ansible/configs/rhel-security/idm.yml
@@ -7,7 +7,7 @@
         state: present
     - command: dig +short +onesoa -x "{{ ansible_default_ipv4.address }}"
       register: dig_out
-    - name: Export node 7 name.
+    - name: Export idmserver node name.
       set_fact:
         node_dns_name: "{{ dig_out.stdout_lines[0][:-1] }}"
       delegate_facts: yes
@@ -27,10 +27,8 @@
         ipaadmin_password: 'r3dh4t1!'
         ipadm_password: 'r3dh4t1!'
 
-- name: Set IPAc lient variables
-  hosts:
-    - node8.*
-    - node9.*
+- name: Set IPA client variables
+  hosts: idm
   become: yes
   tasks:
     - name: Set variables.
@@ -53,10 +51,8 @@
     - role: ipaserver
       state: present
 
-- name: Deploy role ipaclient to nodes 8 and 9
-  hosts:
-    - node8.*
-    - node9.*
+- name: Deploy role ipaclient to idm nodes 1 and 2
+  hosts: idm
   become: yes
   roles:
     - role: ipaclient

--- a/ansible/configs/rhel-security/software.yml
+++ b/ansible/configs/rhel-security/software.yml
@@ -7,28 +7,6 @@
     - debug:
         msg: "Software tasks Started"
 
-- name: Deploy Roles if infra_workloads defined
-  hosts:
-    - nodes
-  gather_facts: false
-  run_once: false
-  become: yes
-  tags:
-    - infra_workloads
-  tasks:
-  - name: apply infra workloads roles on nodes
-    when:
-    - infra_workloads|d("")|length > 0
-    block:
-      - name: Apply role "{{ workload_loop_var }}" on nodes
-        include_role:
-          name: "{{ workload_loop_var }}"
-        vars:
-          ACTION: "provision"
-        loop: "{{ infra_workloads.split(',')|list }}"
-        loop_control:
-          loop_var: workload_loop_var
-
 - name: Configure graphical mode for OpenSCAP and IdM
   hosts:
     - openscap

--- a/ansible/configs/rhel-security/software.yml
+++ b/ansible/configs/rhel-security/software.yml
@@ -29,23 +29,23 @@
         loop_control:
           loop_var: workload_loop_var
 
-- name: Configure graphical mode
+- name: Configure graphical mode for OpenSCAP and IdM
   hosts:
-    - openscaps
+    - openscap
     - idmserver
   become: true
   roles:
     - role: rhel-graphical
 
-- name: Configure OpenSCAP on node openscap
-  hosts: openscaps
+- name: Configure OpenSCAP
+  hosts: openscap
   become: yes
   tasks:
     - name: Setup OpenSCAP
       import_tasks: openscap.yml
 
-- name: Configure AIDE on RHEL 8 node1
-  hosts: node1.*
+- name: Configure AIDE
+  hosts: aide
   become: yes
   tasks:
     - import_tasks: fix-authorized_keys.yml
@@ -53,8 +53,8 @@
     - name: Setup AIDE
       import_tasks: aide.yml
 
-- name: Configure gpg on RHEL 8 node 2
-  hosts: node2.*
+- name: Configure gpg
+  hosts: gpg
   become: yes
   tasks:
     - import_tasks: fix-authorized_keys.yml
@@ -62,8 +62,8 @@
     - name: Setup GPG
       import_tasks: gpg.yml
 
-- name: Configure audit on RHEL 8 node 3
-  hosts: node3.*
+- name: Configure audit
+  hosts: audit
   become: yes
   tasks:
     - import_tasks: fix-authorized_keys.yml
@@ -71,8 +71,8 @@
     - name: Setup AUDIT
       import_tasks: audit.yml
 
-- name: Configure firewalld on RHEL 8 node 4
-  hosts: node4.*
+- name: Configure firewalld
+  hosts: firewalld
   become: yes
   tasks:
     - import_tasks: fix-authorized_keys.yml
@@ -80,21 +80,19 @@
     - name: Setup firewalld
       import_tasks: firewalld.yml
 
-- name: Configure IPSEC 1 on RHEL 8 ipseclab nodes.
-  hosts:
-  - ipsec1.*
-  - ipsec2.*
+- name: Configure IPSEC
+  hosts: ipsec
   become: yes
   tasks:
     - import_tasks: fix-authorized_keys.yml
-    - name: Setup IPSEC 1
+    - name: Setup IPSEC
       import_tasks: ipsec.yml
 
-- name: Configure IdM lab on nodes 7, 8 and 9.
+- name: Configure IdM
   import_playbook: idm.yml
 
-- name: Configure Crypto Policies on RHEL 8 node 10
-  hosts: node10.*
+- name: Configure Crypto Policies
+  hosts: cryptopolicies
   become: yes
   tasks:
     - import_tasks: fix-authorized_keys.yml
@@ -102,8 +100,8 @@
     - name: Setup Crypto Policies
       import_tasks: crypto.yml
 
-- name: Configure Session Recording on RHEL 8 node 11
-  hosts: node11.*
+- name: Configure Session Recording
+  hosts: sessionrecording
   become: yes
   tasks:
     - import_tasks: fix-authorized_keys.yml

--- a/ansible/roles/rhel-graphical/tasks/main.yml
+++ b/ansible/roles/rhel-graphical/tasks/main.yml
@@ -54,23 +54,24 @@
   - name: RHEL 8 Tasks
     block:
 
-    - name: Install GUI components and Xrdp build reqs on RHEL 8
-      command: yum -y install @graphical-server-environment tigervnc-server 'xorg-*' coreutils wget --skip-broken
-      # currently, the group is not properly resolved, against RHUI, with yum
-#      yum:
-#        name:
-#        - "@Server with GUI"
-##        - "@^Server with GUI"
-##        - '@^graphical-server-environment'
-#        - tigervnc-server
-#        - "xorg*"
-#        - coreutils
-#        - wget
-##        exclude:
-##        - fwupdate-efi
-##        - file-roller-nautilus
-#        skip_broken: "yes"
-#        state: present
+    - name: Install GUI components on RHEL 8
+      yum:
+        name:
+        - "@GNOME"
+        - "@Internet Browser"
+        - "@base-x"
+        exclude:
+        - file-roller-nautilus
+        skip_broken: "yes"
+        state: present
+
+    - name: Install Xrdp build reqs on RHEL 8
+      yum:
+        name:
+        - tigervnc-server
+        - "xorg-*"
+        - coreutils
+        - wget
   
     - name: Install XRDP server and dependencies
       yum:

--- a/ansible/roles/rhel-graphical/tasks/main.yml
+++ b/ansible/roles/rhel-graphical/tasks/main.yml
@@ -73,6 +73,9 @@
       yum:
         name:
         - "@GNOME"
+        exclude:
+        - file-roller-nautilus
+        skip_broken: "yes"
         state: present
 
     - name: Install Xrdp build reqs on RHEL 8

--- a/ansible/roles/rhel-graphical/tasks/main.yml
+++ b/ansible/roles/rhel-graphical/tasks/main.yml
@@ -57,12 +57,22 @@
     - name: Install GUI components on RHEL 8
       yum:
         name:
-        - "@GNOME"
-        - "@Internet Browser"
         - "@base-x"
         exclude:
         - file-roller-nautilus
         skip_broken: "yes"
+        state: present
+
+    - name: Install Internet Browser on RHEL 8
+      yum:
+        name:
+        - "@Internet Browser"
+        state: present
+
+    - name: Install GNOME on RHEL 8
+      yum:
+        name:
+        - "@GNOME"
         state: present
 
     - name: Install Xrdp build reqs on RHEL 8

--- a/ansible/roles/rhel-security-verification/tasks/idm-verify.yml
+++ b/ansible/roles/rhel-security-verification/tasks/idm-verify.yml
@@ -5,7 +5,7 @@
 - name: get PTR record for client nodes
   command: dig +short +onesoa -x "{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
   register: node_ptr
-  with_items: ['node8.{{ guid }}.internal', 'node9.{{guid }}.internal']
+  with_items: ['idm1.{{ guid }}.internal', 'idm2.{{ guid }}.internal']
 
 - name: verify if client nodes have been enrolled
   command: ipa host-find "{{ item.stdout[:-1] }}"

--- a/ansible/roles/rhel-security-verification/tasks/main.yml
+++ b/ansible/roles/rhel-security-verification/tasks/main.yml
@@ -1,40 +1,44 @@
 ---
-- name: Verify AIDE on RHEL8 node 1
+- name: Verify AIDE on RHEL8 node aide
   import_tasks: aide-verify.yml
-  when: inventory_hostname_short == "node1"
+  when: inventory_hostname_short == "aide"
 
-- name: Verify gpg on RHEL 8 node 2
+- name: Verify gpg on RHEL 8 node gpg
   import_tasks: gpg-verify.yml
-  when: inventory_hostname_short == "node2"
+  when: inventory_hostname_short == "gpg"
 
-- name: Verify audit on RHEL 8 node 3
+- name: Verify audit on RHEL 8 node audit
   import_tasks: audit-verify.yml
-  when: inventory_hostname_short == "node3"
+  when: inventory_hostname_short == "audit"
 
-- name: Verify firewalld on RHEL 8 node 4
+- name: Verify firewalld on RHEL 8 node firewalld
   import_tasks: firewalld-verify.yml
-  when: inventory_hostname_short == "node4"
+  when: inventory_hostname_short == "firewalld"
 
 - name: Verify ipsec on RHEL 8 node ipsec1
   import_tasks: ipsec-verify.yml
   when: inventory_hostname_short == "ipsec1"
 
-- name: Verify ipsec on RHEL 8 nodes ipsec2
+- name: Verify ipsec on RHEL 8 node ipsec2
   import_tasks: ipsec-verify.yml
   when: inventory_hostname_short == "ipsec2"
 
-- name: Verify idm and clients
+- name: Verify idm and clients on node idm1
   import_tasks: idm-verify.yml
-  when: inventory_hostname_short == "idm"
+  when: inventory_hostname_short == "idm1"
 
-- name: Verify crypto on RHEL 8 on node 10
+- name: Verify idm and clients on node idm2
+  import_tasks: idm-verify.yml
+  when: inventory_hostname_short == "idm2"
+
+- name: Verify crypto on RHEL 8 on node cryptopolicies
   import_tasks: crypto-verify.yml
-  when: inventory_hostname_short == "node10"
+  when: inventory_hostname_short == "cryptopolicies"
 
-- name: Verify session recording on RHEL 8 node 11
+- name: Verify session recording on node sessionrecording
   import_tasks: sessionrecording-verify.yml
-  when: inventory_hostname_short == "node11"
+  when: inventory_hostname_short == "sessionrecording"
 
-- name: Verify OpenSCAP lab on openscap
+- name: Verify OpenSCAP lab on node openscap
   import_tasks: openscap-verify.yml
   when: inventory_hostname_short == "openscap"

--- a/ansible/roles/rhel-security-verification/tasks/sessionrecording-verify.yml
+++ b/ansible/roles/rhel-security-verification/tasks/sessionrecording-verify.yml
@@ -1,15 +1,17 @@
 - name: Gather state of required packages
-  package:
-    name:
-      - tlog
-      - cockpit
-      - cockpit-session-recording
-      - mc
-      - nginx
-      - vim-enhanced
-    state: present
-  check_mode: yes
-  register: packages_installed
+  block:
+    - name: Gather state of required packages
+      package:
+        name:
+          - tlog
+          - cockpit
+          - cockpit-session-recording
+          - mc
+          - nginx
+          - vim-enhanced
+        state: present
+      check_mode: yes
+      register: packages_installed
 
 - name: Check whether required packages are installed
   assert:
@@ -41,7 +43,6 @@
     that: "{{ root_password.changed == false }}"
 
 - name: Gather state of q user
-  user:
   user:
     name: q
     password: $6$CMxicOHc/rbTt9R5$fQYehgVLhm2hLmm7UpfeJ6t6sk5pGxexufgUU9xfkx6mRkwdhi7agjh85M4QMdk71bukeEUV3iASL8P18Anhb1


### PR DESCRIPTION
This one is kinda big. Let's see the improvements here:

- Named each node individually so we don't need to rely on memorizing each node is each exercise. @rjeffman I changed the IPSEC instance to be a regular node, similar to other exercises that don't need GUI.
- Broke down the `rhel-graphical` role where yum installs "Server with GUI" group to install only required packages to make the GUI work. We don't need the extra `server` packages that comes with the group "Server with GUI". This reduces time of deployment by installing less packages.
- I fixed the `sessionrecording-verify.yml` playbook since it had syntax errors
- Removed a useless legacy task from the three-tier-app called `Deploy Roles if infra_workloads defined`.
- Renamed RHEL7 selinux node to `selinuxrhel7` but this one still fails on: `1070 fatal: [selinuxrhel7.guid.internal]: FAILED! => {"changed": false, "msg": "This system has no repositories available through subscriptions"}`. But the deployment finishes successfully since this node is not being used at the moment. We need to take a look when @wrabcak starts to use it. It's probably because we are using RHEL8 repo and this node is RHEL7 then we need to treat it differently.