### PR TITLE
Remove idmserver node and use bastion instead.

### DIFF
--- a/ansible/roles/rhel-graphical/vars/main.yml
+++ b/ansible/roles/rhel-graphical/vars/main.yml
@@ -3,4 +3,4 @@
 
 # this password is used by VNC setup, it should be between 6-8 alphanumeric chars
 student_password: redhat
-student_name: redhat_user
+student_name: ec2-user


### PR DESCRIPTION
@rjeffman Is something like this to remove the idmserver? If the user access the server through its own browser we don't even need to setup the graphical part.