### PR TITLE
Change default username in rhel-graphical to ec2-user.

### DIFF
--- a/ansible/roles/rhel-graphical/vars/main.yml
+++ b/ansible/roles/rhel-graphical/vars/main.yml
@@ -3,4 +3,4 @@
 
 # this password is used by VNC setup, it should be between 6-8 alphanumeric chars
 student_password: redhat
-student_name: redhat_user
+student_name: ec2-user


### PR DESCRIPTION
Fix role `rhel-graphical` where it doesn't find the default username if we don't override the default variable.
