### PR TITLE
Remove temporarily public ip address attribute from NBDE.

### DIFF
--- a/ansible/configs/rhel-security/env_vars.yml
+++ b/ansible/configs/rhel-security/env_vars.yml
@@ -523,7 +523,8 @@ instances:
 
   - name: "nbde"
     count: 3
-    public_dns: true
+    # TODO: enable when we have a solution for number of maximum public IP address. Which is 5 currently in AWS
+    public_dns: false
     dns_loadbalancer: false
     image: "{{ nbde_instance_image }}"
     flavor:


### PR DESCRIPTION
Fix issue with maximum number of public IP address. We still have to come with a better solution.
