### PR TITLE
Enable public dns for session recording.

### DIFF
--- a/ansible/configs/rhel-security/default_vars.yml
+++ b/ansible/configs/rhel-security/default_vars.yml
@@ -468,7 +468,7 @@ instances:
   - name: "sessionrecording"
     count: 1
     unique: true
-    public_dns: false
+    public_dns: true
     dns_loadbalancer: false
     image: "{{ node_instance_image }}"
     flavor: "{{ node_instance_type }}"

--- a/ansible/configs/rhel-security/post_software.yml
+++ b/ansible/configs/rhel-security/post_software.yml
@@ -15,6 +15,7 @@
           OPENSCAP_IP_ADDRESS: "{{ hostvars[groups.openscap.0].public_ip_address }}"
           IDMSERVER_PASSWORD: "{{ hostvars[groups.idmserver.0].student_password }}"
           IDMSERVER_IP_ADDRESS: "{{ hostvars[groups.idmserver.0].public_ip_address }}"
+          SESSIONRECORDING_IP_ADDRESS: "{{ hostvars[groups.sessionrecording.0].public_ip_address }}"
           GUID: "{{ guid }}"
           # GROUPS: "{{ groups }}"
 

--- a/ansible/configs/rhel-security/sessionrecording.yml
+++ b/ansible/configs/rhel-security/sessionrecording.yml
@@ -24,3 +24,9 @@
     name: q
     password: $6$CMxicOHc/rbTt9R5$fQYehgVLhm2hLmm7UpfeJ6t6sk5pGxexufgUU9xfkx6mRkwdhi7agjh85M4QMdk71bukeEUV3iASL8P18Anhb1
     state: present
+
+- name: Allow passwordless sudo for user q
+  lineinfile:
+    path: '/etc/sudoers'
+    state: present
+    line: "q         ALL=(ALL)       NOPASSWD: ALL"


### PR DESCRIPTION
Make session recording node available publicly so we can access cockpit's web interface.